### PR TITLE
made change to make the node filter case insensitive

### DIFF
--- a/KRAGEN_Dashboard/Backend/got.py
+++ b/KRAGEN_Dashboard/Backend/got.py
@@ -451,7 +451,8 @@ You may provide reasoning for your scoring, but the final score should be betwee
                             if len(node_filters) > 1:
                                 for node_filter in node_filters:
                                     # remove knowledge that doesn't contain the node_filter
-                                    knowledge_array = [knowledge for knowledge in knowledge_array if node_filter in knowledge]
+                                    # knowledge_array = [knowledge for knowledge in knowledge_array if node_filter in knowledge]
+                                    knowledge_array = [knowledge for knowledge in knowledge_array if node_filter.lower() in knowledge.lower()]
                             knowledge_arrays.append(knowledge_array)
                         # get the unique union of the knowledge arrays
                         knowledge_array = list(set().union(*knowledge_arrays))


### PR DESCRIPTION
I have modified the code below to ensure the process is case-insensitive. Below, I outline the original approach and the changes made to achieve case insensitivity.

In the original code, the filtering condition node_filter in knowledge checks if the substring node_filter exists within each element of knowledge_array. This method is case sensitive, meaning it only matches strings that exactly replicate the case (uppercase and lowercase) of node_filter.



## Original Code:
```python
knowledge_array = [knowledge for knowledge in knowledge_array if node_filter in knowledge]
```

## Modified Code:
```python
knowledge_array = [knowledge for knowledge in knowledge_array if node_filter.lower() in knowledge.lower()]
```

To address this, I modified the line to include .lower() for both node_filter and knowledge. This method converts both strings to lowercase before performing the substring check, thereby ignoring any case differences.